### PR TITLE
Allow dry-running the OOBGC

### DIFF
--- a/lib/gctools/version.rb
+++ b/lib/gctools/version.rb
@@ -1,0 +1,3 @@
+module GCTools
+  VERSION_STRING = '0.2.3'
+end


### PR DESCRIPTION
This is necessary for proper usage in Phusion Passenger. Passenger must send a message to its HelperAgent, and receive a message back, before it is allowed to invoke any OOBGC. This is how Passenger implements out-of-band work.

The dry-running mode allows Passenger to detect whether there is a need to run the GC. If yes, then it will request out-of-band work, and run the OOBGC in non-dry mode later. This mechanism is similar to what I described at the end of http://blog.phusion.nl/2013/01/22/phusion-passenger-4-technology-preview-out-of-band-work/
