### PR TITLE
Ruby 2.2+ support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    minitest (5.8.3)
     rake (10.1.0)
     rake-compiler (0.9.2)
       rake
@@ -15,4 +16,5 @@ PLATFORMS
 
 DEPENDENCIES
   gctools!
+  minitest (~> 5.0)
   rake-compiler (~> 0.9)

--- a/ext/oobgc/oobgc.c
+++ b/ext/oobgc/oobgc.c
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <sys/time.h>
 #include "ruby/ruby.h"
+#include "ruby/version.h"
 #include "ruby/intern.h"
 #include "ruby/debug.h"
 
@@ -191,7 +192,11 @@ Init_oobgc()
   rb_define_singleton_method(mOOB, "stat", oobgc_stat, 1);
   rb_define_singleton_method(mOOB, "clear", oobgc_clear, 0);
 
-#define S(name, legacy_name) sym_##name = ID2SYM(rb_intern(#legacy_name));
+#if (RUBY_API_VERSION_MAJOR == 2) && (RUBY_API_VERSION_MINOR == 1)
+  #define S(name, legacy_name) sym_##name = ID2SYM(rb_intern(#legacy_name))
+#else
+  #define S(name, legacy_name) sym_##name = ID2SYM(rb_intern(#name))
+#endif
   S(total_allocated_objects, total_allocated_object);
   S(heap_swept_slots, heap_swept_slot);
   S(heap_tomb_pages, heap_tomb_page_length);

--- a/gctools.gemspec
+++ b/gctools.gemspec
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.extensions = ['ext/gcprof/extconf.rb', 'ext/oobgc/extconf.rb']
   s.add_development_dependency 'rake-compiler', '~> 0.9'
+  s.add_development_dependency 'minitest', '~> 5.0'
 end

--- a/test/test_gcprof.rb
+++ b/test/test_gcprof.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'gctools/gcprof'
 
-class TestGCProf < Test::Unit::TestCase
+class TestGCProf < Minitest::Test
   def teardown
     GCProf.after_gc_hook = nil
   end

--- a/test/test_oobgc.rb
+++ b/test/test_oobgc.rb
@@ -3,6 +3,8 @@ require 'gctools/oobgc'
 require 'json'
 
 class TestOOBGC < Minitest::Test
+  HEAP_SWEPT_SLOTS_KEY = RUBY_VERSION >= "2.2" ? :heap_swept_slots : :heap_swept_slot
+
   def setup
     GC::OOB.setup
     GC::OOB.clear
@@ -12,9 +14,9 @@ class TestOOBGC < Minitest::Test
     GC.start(immediate_sweep: false)
     assert_equal false, GC.latest_gc_info(:immediate_sweep)
 
-    before = GC.stat(:heap_swept_slot)
+    before = GC.stat(HEAP_SWEPT_SLOTS_KEY)
     assert_equal true, GC::OOB.run
-    assert_operator GC.stat(:heap_swept_slot), :>, before
+    assert_operator GC.stat(HEAP_SWEPT_SLOTS_KEY), :>, before
   end
 
   def test_oob_mark

--- a/test/test_oobgc.rb
+++ b/test/test_oobgc.rb
@@ -1,8 +1,8 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'gctools/oobgc'
 require 'json'
 
-class TestOOBGC < Test::Unit::TestCase
+class TestOOBGC < Minitest::Test
   def setup
     GC::OOB.setup
     GC::OOB.clear


### PR DESCRIPTION
In Ruby 2.2+ the GC stat symbol names have changed:

https://bugs.ruby-lang.org/issues/9924

This pull request updates gctools to use the new symbol names on Ruby 2.2+ while still using the old legacy symbol names on 2.1.

I've also switched the test suite over to minitest as test/unit is no longer distributed with newer versions of Ruby.