### PR TITLE
Ruby 2.5 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    gctools (0.2.3)
+    gctools (0.2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.8.3)
-    rake (10.1.0)
-    rake-compiler (0.9.2)
+    minitest (5.11.3)
+    rake (12.3.0)
+    rake-compiler (0.9.9)
       rake
 
 PLATFORMS
@@ -18,3 +18,6 @@ DEPENDENCIES
   gctools!
   minitest (~> 5.0)
   rake-compiler (~> 0.9)
+
+BUNDLED WITH
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -25,5 +25,7 @@ require 'gctools/logger'
 ``` ruby
 require 'gctools/oobgc'
 GC::OOB.run # after every request
+
+require 'gctools/oobgc/unicorn_middleware'
 use(GC::OOB::UnicornMiddleware) # in config.ru for unicorn
 ```

--- a/ext/oobgc/oobgc.c
+++ b/ext/oobgc/oobgc.c
@@ -185,7 +185,6 @@ void
 Init_oobgc()
 {
   mOOB = rb_define_module_under(rb_mGC, "OOB");
-  rb_autoload(mOOB, rb_intern_const("UnicornMiddleware"), "gctools/oobgc/unicorn_middleware.rb");
 
   rb_define_singleton_method(mOOB, "setup", install, 0);
   rb_define_singleton_method(mOOB, "run", oobgc, 0);

--- a/test/test_oobgc.rb
+++ b/test/test_oobgc.rb
@@ -14,9 +14,17 @@ class TestOOBGC < Minitest::Test
     GC.start(immediate_sweep: false)
     assert_equal false, GC.latest_gc_info(:immediate_sweep)
 
-    before = GC.stat(HEAP_SWEPT_SLOTS_KEY)
-    assert_equal true, GC::OOB.run
-    assert_operator GC.stat(HEAP_SWEPT_SLOTS_KEY), :>, before
+    # GC.latest_gc_info(:state) added in version 2.2.
+    if RUBY_VERSION < '2.2'
+      # GC.stat(:heap_swept_slots) removed in version 2.4.
+      before = GC.stat(HEAP_SWEPT_SLOTS_KEY)
+      assert_equal true, GC::OOB.run
+      assert_operator GC.stat(HEAP_SWEPT_SLOTS_KEY), :>, before
+    else
+      assert_equal :sweeping, GC.latest_gc_info(:state)
+      assert_equal true, GC::OOB.run
+      assert_equal :none, GC.latest_gc_info(:state)
+    end
   end
 
   def test_oob_mark


### PR DESCRIPTION
This PR contains what I think is a minimal set of changes necessary to compile and run this extension as-is on Ruby 2.4 and 2.5.

Fixes #16.

The one part I'm a little uneasy about is that the `GC.stat(:heap_swept_slots)` counter was removed in Ruby 2.4 due to some internal refactoring of the mark-and-sweep algorithm, and I'm not sure if replacing this counter with ~`0`~ [edit: `heap_marked_slots`] in the calculation of `allocation_limit` will impact this behavior significantly- I don't fully understand the Ruby GC-implementation internals to be confident in that, ~or even whether this will work or be useful in Ruby 2.5 at all for that matter~ [edit: I've run this PR in production for several months now, and it has been useful].

In any case this is a starting point I plan to use for profiling my own web-application through a Ruby upgrade, and I'm sharing it here in case others might find it useful as well.